### PR TITLE
Add no_std support

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,22 @@
 //! This crate defines types and traits for use with `enum-tryfrom-derive` See
 //! the documentation of that crate for usage details.
 
-use std::error::Error;
-use std::fmt::Display;
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[derive(Debug)]
+#[cfg(feature="std")]
+extern crate core;
+
+mod lib {
+    mod core {
+        #[cfg(not(feature = "std"))]
+        pub use core::*;
+        #[cfg(feature = "std")]
+        pub use std::*;
+    }
+}
+
+#[derive(PartialEq, Debug)]
 pub struct InvalidEnumValue(());
-
-const DESCRIPTION : &'static str = "Attempted to convert invalid value to enum";
 
 impl InvalidEnumValue {
     pub fn new() -> Self {
@@ -15,24 +24,3 @@ impl InvalidEnumValue {
     }
 }
 
-impl Display for InvalidEnumValue {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        DESCRIPTION.fmt(fmt)
-    }
-}
-
-impl Error for InvalidEnumValue {
-    fn description(&self) -> &str {
-        DESCRIPTION
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_description() {
-        assert_eq!(InvalidEnumValue::new().description(), DESCRIPTION);
-    }
-}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,4 +1,5 @@
 #![feature(try_from)]
+
 use std::convert::TryFrom;
 
 #[macro_use]


### PR DESCRIPTION
It removes that error string because all `no_std` doesn't have a heap but it could be retained by using features!