### PR TITLE
Enable no_std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
   - rust: nightly
     script:
     - cargo test --all --verbose
+  - rust: nightly
+    script:
+    - cargo test --all --verbose --no-default-features
   # clippy only works on nightly
   - rust: nightly
     install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum-tryfrom"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Kai Wohlfahrt <kai.wohlfahrt@gmail.com>"]
 description = "Error types and traits for use with enum-tryfrom-derive"
 license = "MIT"
@@ -14,7 +14,8 @@ travis-ci = { repository = "https://github.com/kwohlfahrt/enum-tryfrom" }
 members = ["derive"]
 
 [features]
-default = []
+default = ["std"]
+std = []
 
 [dev-dependencies]
 enum-tryfrom-derive = { path = "derive", version = "0.1" }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum-tryfrom-derive"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Kai Wohlfahrt <kai.scorpio@gmail.com>"]
 description = "A crate to derive TryFrom<primitive> for enums"
 license = "MIT"
@@ -18,4 +18,4 @@ default = []
 
 [dev-dependencies]
 # For doc-tests
-enum-tryfrom = { path = "..", version = "0.1" }
+enum-tryfrom = { path = "..", version = "0.2" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 //! This crate defines types and traits for use with `enum-tryfrom-derive` See
 //! the documentation of that crate for usage details.
+#![cfg_attr(not(feature="std"), no_std)]
 
-use std::error::Error;
-use std::fmt::Display;
+#[cfg(feature="std")]
+extern crate core;
+
+use core::fmt::Display;
 
 #[derive(Debug,Default)]
 pub struct InvalidEnumValue(());
@@ -16,20 +19,22 @@ impl InvalidEnumValue {
 }
 
 impl Display for InvalidEnumValue {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
         DESCRIPTION.fmt(fmt)
     }
 }
 
-impl Error for InvalidEnumValue {
+#[cfg(feature="std")]
+impl std::error::Error for InvalidEnumValue {
     fn description(&self) -> &str {
         DESCRIPTION
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature="std"))]
 mod tests {
     use super::*;
+    use std::error::Error;
 
     #[test]
     fn test_description() {


### PR DESCRIPTION
The consensus seems to be adding a default feature ("std") to re-enable
the stdlib. Bump patch version only, as this is backwards-compatible.